### PR TITLE
Fix changesets accidentally publishing major versions with workspace peers

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
+  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": ["shared-library", "webpack-react", "vite-react"]
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,8 @@
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
   "bumpVersionsWithWorkspaceProtocolOnly": true,
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": ["shared-library", "webpack-react", "vite-react"]
 }

--- a/.changeset/olive-pumpkins-pay.md
+++ b/.changeset/olive-pumpkins-pay.md
@@ -1,5 +1,4 @@
 ---
-'shared-library': minor
 '@svg-use/webpack': minor
 '@svg-use/rollup': minor
 '@svg-use/core': minor

--- a/.changeset/ten-cups-wonder.md
+++ b/.changeset/ten-cups-wonder.md
@@ -1,6 +1,4 @@
 ---
-'webpack-react': minor
-'vite-react': minor
 '@svg-use/webpack': minor
 '@svg-use/rollup': minor
 '@svg-use/react': minor

--- a/examples/shared-library/package.json
+++ b/examples/shared-library/package.json
@@ -23,8 +23,8 @@
     "build": "tsx generate-icon-modules.mts && tshy && cp src/icons/*.svg dist/esm/icons"
   },
   "dependencies": {
-    "@svg-use/core": "workspace:*",
-    "@svg-use/react": "workspace:*"
+    "@svg-use/core": "workspace:^0",
+    "@svg-use/react": "workspace:^0"
   },
   "peerDependencies": {
     "react": "^18"

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -14,8 +14,8 @@
     "shared-library": "workspace:*"
   },
   "devDependencies": {
-    "@svg-use/react": "workspace:*",
-    "@svg-use/rollup": "workspace:*",
+    "@svg-use/react": "workspace:^0",
+    "@svg-use/rollup": "workspace:^0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/examples/webpack-react/package.json
+++ b/examples/webpack-react/package.json
@@ -15,8 +15,8 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@svg-use/react": "workspace:*",
-    "@svg-use/webpack": "workspace:*",
+    "@svg-use/react": "workspace:^0",
+    "@svg-use/webpack": "workspace:^0",
     "@swc-node/register": "1.10.9",
     "@swc/core": "^1.7.6",
     "@types/node": "20.14.14",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -46,11 +46,11 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.1.0",
-    "@svg-use/core": "workspace:*",
+    "@svg-use/core": "workspace:^0",
     "rollup": "4.20.0"
   },
   "peerDependencies": {
-    "@svg-use/react": "workspace:^"
+    "@svg-use/react": "workspace:^0"
   },
   "peerDependenciesMeta": {
     "@svg-use/react": {
@@ -58,7 +58,6 @@
     }
   },
   "devDependencies": {
-    "@svg-use/react": "workspace:^",
     "@types/node": "20.14.14"
   },
   "keywords": [

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -45,11 +45,11 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@svg-use/core": "workspace:*",
+    "@svg-use/core": "workspace:^0",
     "loader-utils": "^3.3.1"
   },
   "peerDependencies": {
-    "@svg-use/react": "workspace:^"
+    "@svg-use/react": "workspace:^0"
   },
   "peerDependenciesMeta": {
     "@svg-use/react": {
@@ -57,7 +57,6 @@
     }
   },
   "devDependencies": {
-    "@svg-use/react": "workspace:^",
     "@types/loader-utils": "2.0.6",
     "@types/node": "20.14.14",
     "@types/webpack": "^5.28.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,10 +87,10 @@ importers:
   examples/shared-library:
     dependencies:
       '@svg-use/core':
-        specifier: workspace:*
+        specifier: workspace:^0
         version: link:../../packages/core
       '@svg-use/react':
-        specifier: workspace:*
+        specifier: workspace:^0
         version: link:../../packages/react
       react:
         specifier: ^18
@@ -125,10 +125,10 @@ importers:
         version: link:../shared-library
     devDependencies:
       '@svg-use/react':
-        specifier: workspace:*
+        specifier: workspace:^0
         version: link:../../packages/react
       '@svg-use/rollup':
-        specifier: workspace:*
+        specifier: workspace:^0
         version: link:../../packages/rollup
       '@types/react':
         specifier: ^18.3.3
@@ -159,10 +159,10 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@svg-use/react':
-        specifier: workspace:*
+        specifier: workspace:^0
         version: link:../../packages/react
       '@svg-use/webpack':
-        specifier: workspace:*
+        specifier: workspace:^0
         version: link:../../packages/webpack
       '@swc-node/register':
         specifier: 1.10.9
@@ -245,15 +245,15 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0(rollup@4.20.0)
       '@svg-use/core':
-        specifier: workspace:*
+        specifier: workspace:^0
         version: link:../core
+      '@svg-use/react':
+        specifier: workspace:^0
+        version: link:../react
       rollup:
         specifier: 4.20.0
         version: 4.20.0
     devDependencies:
-      '@svg-use/react':
-        specifier: workspace:^
-        version: link:../react
       '@types/node':
         specifier: 20.14.14
         version: 20.14.14
@@ -261,15 +261,15 @@ importers:
   packages/webpack:
     dependencies:
       '@svg-use/core':
-        specifier: workspace:*
+        specifier: workspace:^0
         version: link:../core
+      '@svg-use/react':
+        specifier: workspace:^0
+        version: link:../react
       loader-utils:
         specifier: ^3.3.1
         version: 3.3.1
     devDependencies:
-      '@svg-use/react':
-        specifier: workspace:^
-        version: link:../react
       '@types/loader-utils':
         specifier: 2.0.6
         version: 2.0.6


### PR DESCRIPTION
Per https://github.com/changesets/changesets/issues/1011 and https://github.com/changesets/changesets/issues/1279, changesets seems to publish a major version, when a minor version of a workspace peer is updated. I am not 100% clear on why this happens, but the result seems unintended.

This PR follows the advice in the linked issue, to always use version specifiers for `workspace:` dependencies, as well as `onlyUpdatePeerDependentsWhenOutOfRange`.
