### PR TITLE
Add monochromeCssVarFallback to defaultThemeSubstitution

### DIFF
--- a/.changeset/tricky-bobcats-count.md
+++ b/.changeset/tricky-bobcats-count.md
@@ -1,0 +1,16 @@
+---
+'@svg-use/core': minor
+---
+
+Breaking: `defaultThemeSubstitution` now takes an option object, so its
+signature has changed to a factory:
+
+```diff-js
+const options = {
+-  getThemeSubstitutions: defaultThemeSubstitution
++  getThemeSubstitutions: defaultThemeSubstitution()
+}
+```
+
+`defaultThemeSubstitution` now provides a `monochromeCssVarFallback` option, to
+allow passing `currentColor` as the `var()` fallback.

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -88,7 +88,7 @@ jobs:
     # Do not leave a comment on forks, or for renovate branches
     if: |
       !cancelled() &&
-      needs.playwright.result != '' &&
+      needs.playwright.result == 'failure' &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == 'fpapado/svg-use' &&
       github.actor != 'renovate[bot]'
@@ -98,7 +98,6 @@ jobs:
 
     steps:
       - name: Build help body
-        if: needs.playwright.result == 'failure'
         id: help-body
         env:
           REPOSITORY: "${{github.repository}}"

--- a/examples/shared-library/generate-icon-modules.mts
+++ b/examples/shared-library/generate-icon-modules.mts
@@ -38,7 +38,7 @@ async function processFile(filePath: string) {
 
   const transformResult = transformSvgForUseHref(initialContent, {
     getSvgIdAttribute: defaultGetSvgIdAttribute,
-    getThemeSubstitutions: defaultThemeSubstitution,
+    getThemeSubstitutions: defaultThemeSubstitution(),
   });
 
   if (transformResult.type === 'failure') {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -33,7 +33,7 @@ import {
 function transformAndWriteModule(content: string) {
   const transformResult = transformSvgForUseHref(content, {
     getSvgIdAttribute: defaultGetSvgIdAttribute,
-    getThemeSubstitutions: defaultThemeSubstitution,
+    getThemeSubstitutions: defaultThemeSubstitution(),
   });
 
   if (transformResult.type === 'failure') {

--- a/packages/core/src/theme/defaultTheme.ts
+++ b/packages/core/src/theme/defaultTheme.ts
@@ -11,40 +11,66 @@ const substituteCustomProperty = (
   fallbackValue: string,
 ) => (property ? `var(--${property}, ${fallbackValue})` : fallbackValue);
 
+export type DefaultThemeOptions = {
+  /**
+   * Configures the CSS var() fallback for monochrome icons.
+   *
+   * This can make monochrome icons simpler to use, at the expense of
+   * consistency (or lack thereof) with duotone and tritone icons.
+   *
+   * 'existingValue' uses the color that already exists in the SVG, such as
+   * `var(--svg-use-color-primary, #123123)`
+   *
+   * 'currentColor' substitutes any existing color with 'currentColor', such as
+   * `var(--svg-use-color-primary, currentColor)`
+   *
+   * @defaultValue 'exitingValue'
+   */
+  monochromeCssVarFallback?: 'existingValue' | 'currentColor';
+};
+
 /**
  * The default theme function. Substitutes up to three sizes and strokes with
  * custom properties. Preserves existing properties as fallbacks.
  *
  * @category Primary function defaults
  */
-export const defaultThemeSubstitution: GetThemeSubstitutionFunction = ({
-  fills,
-  strokes,
-}) => {
-  // We treat identical values the same, regardless of the attribute that they
-  // are used for
-  const mergedColors = Array.from(
-    [...fills.entries(), ...strokes.entries()]
-      .reduce((acc, [color, count]) => {
-        acc.set(color, (acc.get(color) ?? 0) + count);
-        return acc;
-      }, new Map<string, number>())
-      .entries(),
-  ).sort((a, b) => (a[1] = b[1]));
+export const defaultThemeSubstitution =
+  ({
+    monochromeCssVarFallback = 'existingValue',
+  }: DefaultThemeOptions = {}): GetThemeSubstitutionFunction =>
+  ({ fills, strokes }) => {
+    // We treat identical values the same, regardless of the attribute that they
+    // are used for
+    const mergedColors = Array.from(
+      [...fills.entries(), ...strokes.entries()]
+        .reduce((acc, [color, count]) => {
+          acc.set(color, (acc.get(color) ?? 0) + count);
+          return acc;
+        }, new Map<string, number>())
+        .entries(),
+    ).sort((a, b) => (a[1] = b[1]));
 
-  if (mergedColors.length > 3) {
-    throw new Error(
-      'Cannot substitute theme for SVGs with more than 3 colors. Use a resource query to mark this SVG as unthemed.',
+    if (mergedColors.length > 3) {
+      throw new Error(
+        'Cannot substitute theme for SVGs with more than 3 colors. Use a resource query to mark this SVG as unthemed.',
+      );
+    }
+
+    const isMonochrome = mergedColors.length === 1;
+
+    const substitutions = mergedColors.map(
+      ([color], i) =>
+        [
+          color,
+          isMonochrome && monochromeCssVarFallback === 'currentColor'
+            ? substituteCustomProperty(customProperties.at(i), 'currentColor')
+            : substituteCustomProperty(customProperties.at(i), color),
+        ] as const,
     );
-  }
 
-  const substitutions = mergedColors.map(
-    ([color], i) =>
-      [color, substituteCustomProperty(customProperties.at(i), color)] as const,
-  );
-
-  return {
-    fills: new Map(substitutions),
-    strokes: new Map(substitutions),
+    return {
+      fills: new Map(substitutions),
+      strokes: new Map(substitutions),
+    };
   };
-};

--- a/packages/core/src/theme/theme.spec.ts
+++ b/packages/core/src/theme/theme.spec.ts
@@ -4,7 +4,7 @@ import { defaultThemeSubstitution } from './defaultTheme.js';
 describe('defaultThemeSubstitution', () => {
   it('returns the expected substitutions, in sorted order', () => {
     expect(
-      defaultThemeSubstitution({
+      defaultThemeSubstitution()({
         fills: new Map([
           ['#123', 3],
           ['red', 2],
@@ -30,9 +30,23 @@ describe('defaultThemeSubstitution', () => {
     });
   });
 
+  it('provides an option to fall back to currentColor for monochrome icons', () => {
+    expect(
+      defaultThemeSubstitution({ monochromeCssVarFallback: 'currentColor' })({
+        fills: new Map([['#123', 3]]),
+        strokes: new Map([['#123', 3]]),
+      }),
+    ).toEqual({
+      fills: new Map([['#123', 'var(--svg-use-color-primary, currentColor)']]),
+      strokes: new Map([
+        ['#123', 'var(--svg-use-color-primary, currentColor)'],
+      ]),
+    });
+  });
+
   it('throws when there are more than three colors', () => {
     expect(() =>
-      defaultThemeSubstitution({
+      defaultThemeSubstitution()({
         fills: new Map([
           ['#123', 3],
           ['red', 2],

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -61,7 +61,7 @@ const hasNoTheme = (id: string) => {
 const defaultOptions = {
   componentFactory: defaultComponentFactory,
   getSvgIdAttribute: defaultGetSvgIdAttribute,
-  getThemeSubstitutions: defaultThemeSubstitution,
+  getThemeSubstitutions: defaultThemeSubstitution(),
 } satisfies PluginOptions;
 
 function svgUsePlugin(

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -37,7 +37,7 @@ const defaultOptions = {
   svgAssetFilename: '[name]-[contenthash].[ext]',
   componentFactory: defaultComponentFactory,
   getSvgIdAttribute: defaultGetSvgIdAttribute,
-  getThemeSubstitutions: defaultThemeSubstitution,
+  getThemeSubstitutions: defaultThemeSubstitution(),
 } satisfies LoaderOptions;
 
 export default function svgUseLoader(


### PR DESCRIPTION
This adds a small convenience for monochrome icons. I'm a bit reluctant to add keep extending `defaultThemeSubstitution` with extra options, especially when the whole function is only a few lines of code. However, it's probably good for theme transforms to be factories, so that they can be extended without breaking the signature.