### PR TITLE
Fix react svg types to SVGAttributes instead of HTMLAttributes

### DIFF
--- a/.changeset/twelve-forks-cry.md
+++ b/.changeset/twelve-forks-cry.md
@@ -1,0 +1,8 @@
+---
+'@svg-use/react': minor
+---
+
+Breaking change: `Props` now extend `SVGAttributes<SVGSVGElement>` instead of
+`HTMLAttributes<SVGSVGElement>`. This should be _more_ permissive in most
+practical SVG cases, but it might cause type errors with existing uses of
+`ThemedExternalSvg`.

--- a/FUTURE.md
+++ b/FUTURE.md
@@ -25,7 +25,7 @@ implemented.
 ## CSS Linked Parameters
 
 If [CSS Linked Parameters](https://drafts.csswg.org/css-link-params/) lands, you
-will be able to pass custom properties to SVGs inside of `img[href]`.
+will be able to pass custom properties to SVGs inside of `img[src]`.
 
 This avoids the setup with `svg > use[href]`, in favour of the much simpler
 `img` element. An `img` can already be loaded cross-origin, so this also avoids

--- a/TODO.md
+++ b/TODO.md
@@ -2,10 +2,8 @@
 
 ## v1
 
-- Add `{monochromeBehavior?: 'use-currentColor-fallback'}` to default theme
-  transform
 - Consider customising the prefix of custom properties, both in the default
-  theme and in react
+  theme and in react components.
 - Unit test the rest of svg-use/core, for consistency
 - Consider providing the defaults for svg-use/core functions directly in the
   functions themselves.

--- a/packages/core/api-docs/functions/defaultThemeSubstitution.md
+++ b/packages/core/api-docs/functions/defaultThemeSubstitution.md
@@ -6,39 +6,20 @@
 
 # Function: defaultThemeSubstitution()
 
-> **defaultThemeSubstitution**(`counts`): `object`
+> **defaultThemeSubstitution**(`__namedParameters`):
+> [`GetThemeSubstitutionFunction`](../type-aliases/GetThemeSubstitutionFunction.md)
 
 The default theme function. Substitutes up to three sizes and strokes with
 custom properties. Preserves existing properties as fallbacks.
 
 ## Parameters
 
-• **counts**
-
-• **counts.fills**:
-[`Map`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)\<`string`,
-`number`\>
-
-• **counts.strokes**:
-[`Map`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)\<`string`,
-`number`\>
+• **\_\_namedParameters**: `DefaultThemeOptions` = `{}`
 
 ## Returns
 
-`object`
-
-### fills
-
-> **fills**:
-> [`Map`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)\<`string`,
-> `string`\>
-
-### strokes
-
-> **strokes**:
-> [`Map`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map)\<`string`,
-> `string`\>
+[`GetThemeSubstitutionFunction`](../type-aliases/GetThemeSubstitutionFunction.md)
 
 ## Defined in
 
-[theme/defaultTheme.ts:26](https://github.com/fpapado/svg-use/blob/main/packages/core/src/theme/defaultTheme.ts#L26)
+[theme/defaultTheme.ts:39](https://github.com/fpapado/svg-use/blob/main/packages/core/src/theme/defaultTheme.ts#L39)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -26,6 +26,26 @@ const MyComponent = () => {
 };
 ```
 
+Optionally, in your application root, you can pass config via context:
+
+```tsx
+import { configContext, type Config } from '@svg-use/react';
+
+const config: Config = {
+  // Add any config options here
+  rewritePath: (pathOrHref) => pathOrHref,
+  runtimeChecksEnabled: process.env.NODE_ENV !== 'production',
+};
+
+const AppRoot = () => {
+  return (
+    <configContext.Provider value={config}>
+      {/* The rest of your application */}
+    </configContext.Provider>
+  );
+};
+```
+
 ## API Reference
 
 [Find the full API reference](./api-docs/README.md)

--- a/packages/react/api-docs/functions/ThemedExternalSvg.md
+++ b/packages/react/api-docs/functions/ThemedExternalSvg.md
@@ -16,7 +16,7 @@ setting the color.
 
 • **props**: [`BaseProps`](../interfaces/BaseProps.md) &
 [`ThemeProps`](../interfaces/ThemeProps.md) &
-`HTMLAttributes`\<[`SVGSVGElement`](https://developer.mozilla.org/docs/Web/API/SVGSVGElement)\>
+`SVGAttributes`\<[`SVGSVGElement`](https://developer.mozilla.org/docs/Web/API/SVGSVGElement)\>
 &
 `RefAttributes`\<[`SVGSVGElement`](https://developer.mozilla.org/docs/Web/API/SVGSVGElement)\>
 
@@ -26,4 +26,4 @@ setting the color.
 
 ## Defined in
 
-[packages/react/src/ThemedExternalSvg.tsx:96](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L96)
+[packages/react/src/ThemedExternalSvg.tsx:95](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L95)

--- a/packages/react/api-docs/functions/createThemedExternalSvg.md
+++ b/packages/react/api-docs/functions/createThemedExternalSvg.md
@@ -8,8 +8,9 @@
 
 > **createThemedExternalSvg**(`__namedParameters`): (`props`) => `Element`
 
-A component factory for [ThemedExternalSvg](ThemedExternalSvg.md). Useful for
-module organisation, and as a target for `@svg-use/core`'s `createJsModule`.
+A component factory for a specific [ThemedExternalSvg](ThemedExternalSvg.md),
+which bakes in its url, id and viewBox. Useful for module organisation, and as a
+target for `@svg-use/core`'s `createJsModule` factory function.
 
 ## Parameters
 
@@ -30,4 +31,4 @@ module organisation, and as a target for `@svg-use/core`'s `createJsModule`.
 
 ## Defined in
 
-[packages/react/src/ThemedExternalSvg.tsx:164](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L164)
+[packages/react/src/ThemedExternalSvg.tsx:158](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L158)

--- a/packages/react/api-docs/interfaces/BaseProps.md
+++ b/packages/react/api-docs/interfaces/BaseProps.md
@@ -16,7 +16,7 @@ The id of the referent icon, in the destination SVG.
 
 #### Defined in
 
-[packages/react/src/ThemedExternalSvg.tsx:82](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L82)
+[packages/react/src/ThemedExternalSvg.tsx:81](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L81)
 
 ---
 
@@ -30,7 +30,7 @@ no mechanism for cross-origin svg[use].
 
 #### Defined in
 
-[packages/react/src/ThemedExternalSvg.tsx:80](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L80)
+[packages/react/src/ThemedExternalSvg.tsx:79](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L79)
 
 ---
 
@@ -42,4 +42,4 @@ The viewBox of the referent SVG; used to ensure the same scaling.
 
 #### Defined in
 
-[packages/react/src/ThemedExternalSvg.tsx:84](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L84)
+[packages/react/src/ThemedExternalSvg.tsx:83](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L83)

--- a/packages/react/api-docs/interfaces/ThemeProps.md
+++ b/packages/react/api-docs/interfaces/ThemeProps.md
@@ -8,9 +8,19 @@
 
 ## Properties
 
-### fill?
+### color?
 
-> `optional` **fill**: `string`
+> `optional` **color**: `string`
+
+#### Defined in
+
+[packages/react/src/ThemedExternalSvg.tsx:68](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L68)
+
+---
+
+### colorSecondary?
+
+> `optional` **colorSecondary**: `string`
 
 #### Defined in
 
@@ -18,50 +28,10 @@
 
 ---
 
-### fillSecondary?
+### colorTertiary?
 
-> `optional` **fillSecondary**: `string`
+> `optional` **colorTertiary**: `string`
 
 #### Defined in
 
 [packages/react/src/ThemedExternalSvg.tsx:70](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L70)
-
----
-
-### fillTertiary?
-
-> `optional` **fillTertiary**: `string`
-
-#### Defined in
-
-[packages/react/src/ThemedExternalSvg.tsx:71](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L71)
-
----
-
-### stroke?
-
-> `optional` **stroke**: `string`
-
-#### Defined in
-
-[packages/react/src/ThemedExternalSvg.tsx:66](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L66)
-
----
-
-### strokeSecondary?
-
-> `optional` **strokeSecondary**: `string`
-
-#### Defined in
-
-[packages/react/src/ThemedExternalSvg.tsx:67](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L67)
-
----
-
-### strokeTertiary?
-
-> `optional` **strokeTertiary**: `string`
-
-#### Defined in
-
-[packages/react/src/ThemedExternalSvg.tsx:68](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L68)

--- a/packages/react/api-docs/type-aliases/FactoryProps.md
+++ b/packages/react/api-docs/type-aliases/FactoryProps.md
@@ -24,4 +24,4 @@
 
 ## Defined in
 
-[packages/react/src/ThemedExternalSvg.tsx:155](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L155)
+[packages/react/src/ThemedExternalSvg.tsx:148](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L148)

--- a/packages/react/api-docs/type-aliases/Props.md
+++ b/packages/react/api-docs/type-aliases/Props.md
@@ -8,8 +8,8 @@
 
 > **Props**: [`BaseProps`](../interfaces/BaseProps.md) &
 > [`ThemeProps`](../interfaces/ThemeProps.md) &
-> `HTMLAttributes`\<[`SVGSVGElement`](https://developer.mozilla.org/docs/Web/API/SVGSVGElement)\>
+> `SVGAttributes`\<[`SVGSVGElement`](https://developer.mozilla.org/docs/Web/API/SVGSVGElement)\>
 
 ## Defined in
 
-[packages/react/src/ThemedExternalSvg.tsx:87](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L87)
+[packages/react/src/ThemedExternalSvg.tsx:86](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L86)

--- a/packages/react/api-docs/variables/configContext.md
+++ b/packages/react/api-docs/variables/configContext.md
@@ -35,4 +35,4 @@ const AppRoot = () => {
 
 ## Defined in
 
-[packages/react/src/ThemedExternalSvg.tsx:61](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L61)
+[packages/react/src/ThemedExternalSvg.tsx:63](https://github.com/fpapado/svg-use/blob/main/packages/react/src/ThemedExternalSvg.tsx#L63)

--- a/packages/react/api-docs/variables/configContext.md
+++ b/packages/react/api-docs/variables/configContext.md
@@ -20,6 +20,8 @@ import { configContext, type Config } from '@svg-use/react';
 
 const config: Config = {
   // Add any config options here
+  rewritePath: (pathOrHref) => pathOrHref,
+  runtimeChecksEnabled: process.env.NODE_ENV !== 'production',
 };
 
 const AppRoot = () => {

--- a/packages/react/src/ThemedExternalSvg.tsx
+++ b/packages/react/src/ThemedExternalSvg.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, HTMLAttributes } from 'react';
+import type { CSSProperties, HTMLAttributes, SVGAttributes } from 'react';
 import {
   createContext,
   forwardRef,
@@ -83,7 +83,7 @@ export interface BaseProps {
   viewBox: string;
 }
 
-export type Props = BaseProps & ThemeProps & HTMLAttributes<SVGSVGElement>;
+export type Props = BaseProps & ThemeProps & SVGAttributes<SVGSVGElement>;
 
 /**
  * The main React component, which wires up `svg > use[href]`, as well as the

--- a/packages/react/src/ThemedExternalSvg.tsx
+++ b/packages/react/src/ThemedExternalSvg.tsx
@@ -25,8 +25,8 @@ export type Config = {
   rewritePath?: (pathOrHref: string) => string;
 
   /**
-   * Toggles runtime checks, which help catch common pitfalls with using external
-   * SVGs, such as needing to be on the same origin.
+   * Toggles runtime checks, which help catch common pitfalls with using
+   * external SVGs, such as needing to be on the same origin.
    *
    * @defaultValue true
    */
@@ -36,8 +36,8 @@ export type Config = {
 /**
  * A context that you can use to customise the runtime behavior of
  * `ThemedExternalSvg`. Because `ThemedExternalSvg` is usually a compilation
- * target, this allows you to inject configuration without changing the signature
- * of modules.
+ * target, this allows you to inject configuration without changing the
+ * signature of modules.
  *
  * @category Primary exports
  *
@@ -47,6 +47,8 @@ export type Config = {
  *
  * const config: Config = {
  *   // Add any config options here
+ *   rewritePath: (pathOrHref) => pathOrHref,
+ *   runtimeChecksEnabled: process.env.NODE_ENV !== 'production',
  * };
  *
  * const AppRoot = () => {
@@ -148,7 +150,7 @@ export type FactoryProps = { url: string; id: string; viewBox: string };
 /**
  * A component factory for a specific {@link ThemedExternalSvg}, which bakes in
  * its url, id and viewBox. Useful for module organisation, and as a target for
- * `@svg-use/core`'s `createJsModule`.
+ * `@svg-use/core`'s `createJsModule` factory function.
  *
  * @category Primary exports
  */


### PR DESCRIPTION
- **Documentation fixups**
- **Extend Props from SVGAttributes<SVGSVGElement>**
- **Regeenerate docs**
