### PR TITLE
Make svg-use/react a dependency of the plugins

### DIFF
--- a/.changeset/flat-rabbits-allow.md
+++ b/.changeset/flat-rabbits-allow.md
@@ -1,0 +1,7 @@
+---
+'@svg-use/webpack': patch
+'@svg-use/rollup': patch
+'@svg-use/vite': patch
+---
+
+Make `@svg-use/react` a dependency of plugins.

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -48,15 +48,8 @@
   "dependencies": {
     "@rollup/pluginutils": "^5.1.0",
     "@svg-use/core": "workspace:^0.3.0",
+    "@svg-use/react": "workspace:^0.3.0",
     "rollup": "4.20.0"
-  },
-  "peerDependencies": {
-    "@svg-use/react": "workspace:^0.3.0"
-  },
-  "peerDependenciesMeta": {
-    "@svg-use/react": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@types/node": "20.16.1"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -48,14 +48,6 @@
   "dependencies": {
     "@svg-use/rollup": "workspace:^0.4.0"
   },
-  "peerDependencies": {
-    "@svg-use/react": "workspace:^0.3.0"
-  },
-  "peerDependenciesMeta": {
-    "@svg-use/react": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/node": "20.16.1",
     "vite": "^5.4.2"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -47,15 +47,8 @@
   },
   "dependencies": {
     "@svg-use/core": "workspace:^0.3.0",
+    "@svg-use/react": "workspace:^0.3.0",
     "loader-utils": "^3.3.1"
-  },
-  "peerDependencies": {
-    "@svg-use/react": "workspace:^0.3.0"
-  },
-  "peerDependenciesMeta": {
-    "@svg-use/react": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@types/loader-utils": "2.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,9 +269,6 @@ importers:
 
   packages/vite:
     dependencies:
-      '@svg-use/react':
-        specifier: workspace:^0.3.0
-        version: link:../react
       '@svg-use/rollup':
         specifier: workspace:^0.4.0
         version: link:../rollup


### PR DESCRIPTION
This works around a changesets quirk, whereby it bumps 0.x versions to 1.0 if a peerDependency changes. Not too thrilled about this, but we can revisit for 1.0.
