### PR TITLE
Fix: respect `server.config.base` in Vite dev mode

### DIFF
--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -b && vite build",
     "check-types": "tsc --noEmit",
     "dev": "vite",
+    "dev:based": "vite --base=/vite-react",
     "preview": "vite preview",
     "test:e2e": "playwright test"
   },


### PR DESCRIPTION
### Problem
Urls generated by `@svg-use/vite` do not include [base](https://vite.dev/config/shared-options.html#base) option. This becomes problematic when working with proxied setups like mine, where requests to Vite are routed through a proxy. Without the base path included in the URLs, the SVG resources become unreachable through the proxy configuration.

#### Before
`http://localhost:5173/@svg-use//Users/mcler/Projects/svg-use/examples/vite-react/src/assets/arrow.svg?svgUse#use-href-target`

#### After
`http://localhost:5173/vite-react/@svg-use/Users/mcler/Projects/svg-use/examples/vite-react/src/assets/arrow.svg?svgUse#use-href-target`


How to test
```bash
cd examples/vite-react
pp dev
pp dev:based # with `base` option
```