### PR TITLE
fix(vite): use posix paths on Windows

### DIFF
--- a/.changeset/rich-lions-lay.md
+++ b/.changeset/rich-lions-lay.md
@@ -1,0 +1,5 @@
+---
+'@svg-use/vite': patch
+---
+
+Use POSIX path.join for generated SVG asset ids

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,6 +1,6 @@
 import type { PluginOption, Plugin } from 'vite';
 import svgUseRollup, { type PluginOptions } from '@svg-use/rollup';
-import path from 'node:path';
+import path from 'node:path/posix';
 import stream from 'node:stream';
 
 export type { PluginOptions } from '@svg-use/rollup';


### PR DESCRIPTION
Currently, the devPrefixedId utility, which is used to generate URLs for SVG icons, uses `path.join` to concatenate paths. However, on Windows, `path.join` normalizes paths and replaces forward slashes (`/`) with backslashes (`\`). Because of this, the SVG assets never load, since they have backslashes in `svgAssets` but forward slashes in `req.url`.

This PR fixes this by replacing the use of the `path` module with `path/posix`.